### PR TITLE
Fix PlayCard waiting-for-input message

### DIFF
--- a/Phase.cs
+++ b/Phase.cs
@@ -67,7 +67,7 @@ namespace CombatCore
         {
             if (s_context.CurrentPhase != PhaseId.PLAYER_PHASE || !s_context.WaitingForInput)
             {
-                Console.WriteLine($"當前不能使用卡牌：Phase={s_context.CurrentPhase}, WaitingInput={s_context.WaitingForInput}");
+                Console.WriteLine($"當前不能使用卡牌：Phase={s_context.CurrentPhase}, WaitingForInput={s_context.WaitingForInput}");
                 return false;
             }
             


### PR DESCRIPTION
## Summary
- Align PlayCard error message with PhaseContext.WaitingForInput field

## Testing
- `dotnet build` *(failed: command not found)*
- `apt-get update` *(failed: repository not signed 403)*

------
https://chatgpt.com/codex/tasks/task_e_688bba897454832bb97eb7a7b0adc2a6