### PR TITLE
Advance phase after successful card play

### DIFF
--- a/Phase.cs
+++ b/Phase.cs
@@ -81,10 +81,11 @@ namespace CombatCore
             
             // 使用卡牌系統
             bool success = SimpleDeckManager.UseCard(handIndex, targetId);
-            
+
             if (success)
             {
                 s_context.WaitingForInput = false;
+                s_context.CurrentStep = PhaseStep.PROCESS;
                 Console.WriteLine($"✅ 成功使用卡牌 {handIndex}: {hand[handIndex].Name}");
             }
             else


### PR DESCRIPTION
## Summary
- ensure PlayCard exits input wait and advances to processing on success

## Testing
- `dotnet build` *(fails: command not found)*
- `apt-get update >/tmp/apt.log && tail -n 20 /tmp/apt.log` *(fails: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_e_688bb5615bf4832b9a40e2a452041d41