### PR TITLE
Trigger damage event on deflect

### DIFF
--- a/Command.cs
+++ b/Command.cs
@@ -269,7 +269,9 @@ namespace CombatCore
                 return new CommandResult(false, 0, "反彈參與者已死亡");
             
             ushort deflectedDamage = ActorOperations.DealDamage(cmd.SrcId, cmd.Value);
-            
+
+            SimpleEventSystem.OnActorDamaged(cmd.SrcId, cmd.TargetId, deflectedDamage);
+
             if (!ActorManager.IsAlive(cmd.SrcId))
             {
                 PushDelayedCmd(new AtomicCmd(CmdOp.ACTOR_DEATH, 0, cmd.SrcId, 0));


### PR DESCRIPTION
## Summary
- fire OnActorDamaged when a deflect deals damage

## Testing
- `dotnet test` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_e_688e518f3e90832bb93eb4c55c489a44