### PR TITLE
Expose hand as span and avoid caching

### DIFF
--- a/Phase.cs
+++ b/Phase.cs
@@ -79,6 +79,9 @@ namespace CombatCore
                 return false;
             }
             
+            // 先記錄欲使用的卡牌
+            var card = hand[handIndex];
+
             // 使用卡牌系統
             bool success = SimpleDeckManager.UseCard(handIndex, targetId);
 
@@ -86,7 +89,7 @@ namespace CombatCore
             {
                 s_context.WaitingForInput = false;
                 s_context.CurrentStep = PhaseStep.PROCESS;
-                Console.WriteLine($"✅ 成功使用卡牌 {handIndex}: {hand[handIndex].Name}");
+                Console.WriteLine($"✅ 成功使用卡牌 {handIndex}: {card.Name}");
             }
             else
             {

--- a/SimplifiedCardSystem.cs
+++ b/SimplifiedCardSystem.cs
@@ -4,6 +4,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Runtime.InteropServices;
 
 namespace CombatCore
 {
@@ -320,7 +321,7 @@ namespace CombatCore
         public static ReadOnlySpan<SimpleCard> GetHand()
         {
             EnsureInitialized();
-            return s_hand.ToArray().AsSpan();
+            return CollectionsMarshal.AsSpan(s_hand);
         }
         
         // ✅ 增強：獲取可用卡牌資訊

--- a/test_program.cs
+++ b/test_program.cs
@@ -192,31 +192,38 @@ namespace CombatCoreTest
             SimpleDeckManager.DebugPrintHand();
             
             // 測試各種卡牌使用
-            var hand = SimpleDeckManager.GetHand();
-            Console.WriteLine($"\n開始測試 {hand.Length} 張卡牌的使用:");
-            
-            for (int i = 0; i < Math.Min(hand.Length, 3); i++) // 只測試前3張
+            var initialHand = SimpleDeckManager.GetHand();
+            Console.WriteLine($"\n開始測試 {initialHand.Length} 張卡牌的使用:");
+
+            for (int i = 0; i < 3; i++) // 只測試前3張
             {
+                var hand = SimpleDeckManager.GetHand();
+                if (i >= hand.Length)
+                {
+                    Console.WriteLine("手牌已用完");
+                    break;
+                }
+
                 var card = hand[i];
                 Console.WriteLine($"\n--- 測試卡牌 {i}: [{card.Symbol}] {card.Name} ---");
-                
+
                 // 記錄使用前狀態
                 PrintActorStatus(playerId, "玩家", "使用前");
                 PrintActorStatus(enemyId, "敵人", "使用前");
-                
+
                 // 選擇目標
                 byte targetId = card.RequiresTarget ? enemyId : (byte)0;
-                
+
                 // 使用卡牌
                 bool success = SimpleDeckManager.UseCard(i, targetId);
                 Console.WriteLine($"使用結果: {(success ? "✅ 成功" : "❌ 失敗")}");
-                
+
                 // 記錄使用後狀態
                 PrintActorStatus(playerId, "玩家", "使用後");
                 PrintActorStatus(enemyId, "敵人", "使用後");
-                
+
                 Console.WriteLine($"剩餘手牌數: {SimpleDeckManager.GetHandSize()}");
-                
+
                 if (SimpleDeckManager.GetHandSize() == 0)
                 {
                     Console.WriteLine("手牌已用完");


### PR DESCRIPTION
## Summary
- Return hand list as a span via `CollectionsMarshal.AsSpan`
- Safely use spans by capturing cards before mutations and refreshing hand views

## Testing
- `dotnet build` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed, 403)*

------
https://chatgpt.com/codex/tasks/task_e_688e523f0ce0832bb83606635d499ec9