### PR TITLE
Add initialization checks to deck/hand size getters

### DIFF
--- a/SimplifiedCardSystem.cs
+++ b/SimplifiedCardSystem.cs
@@ -379,8 +379,16 @@ namespace CombatCore
         
         // 獲取牌組資訊
         public static DeckConfig GetCurrentConfig() => s_currentConfig;
-        public static int GetHandSize() => s_hand.Count;
-        public static int GetDeckSize() => s_deck.Count;
+        public static int GetHandSize()
+        {
+            EnsureInitialized();
+            return s_hand.Count;
+        }
+        public static int GetDeckSize()
+        {
+            EnsureInitialized();
+            return s_deck.Count;
+        }
         public static CardUsageStats GetStats() => s_stats;
         
         // ✅ 增強：獲取手牌構成統計


### PR DESCRIPTION
## Summary
- ensure SimpleDeckManager.GetHandSize and GetDeckSize call EnsureInitialized

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_688e5e444448832b8ef4b68a8f0bfecd