### PR TITLE
refactor: centralize turn end cleanup

### DIFF
--- a/Phase.cs
+++ b/Phase.cs
@@ -312,16 +312,13 @@ namespace CombatCore
         
         private static PhaseResult Cleanup_Process()
         {
-            // ✅ 觸發回合結束事件
-            SimpleEventSystem.OnTurnEnd();
-            
-            // 推入回合結束清理命令
+            // 推入回合結束清理命令，由命令系統統一處理事件與狀態
             CommandSystem.PushCmd(AtomicCmd.TurnEndCleanup());
             CommandSystem.ExecuteAll();
-            
+
             // ✅ 新增：卡牌系統回合結束處理
             SimpleDeckManager.OnTurnEnd();
-            
+
             s_context.CurrentStep = PhaseStep.END;
             return PhaseResult.NEXT_STEP;
         }


### PR DESCRIPTION
## Summary
- centralize end-of-turn cleanup logic in `ActorManager.EndTurnCleanup`
- simplify `CommandSystem.HandleTurnEndCleanup` to delegate to `ActorManager`
- trigger turn end event only via `TURN_END_CLEANUP` atomic command

## Testing
- `dotnet build` *(fails: command not found)*
- `apt-get update` *(fails: The repository is not signed/403)*

------
https://chatgpt.com/codex/tasks/task_e_688f7d9ddb3c832b92187126040206e3